### PR TITLE
Adiciona query string para ordenaçao dos resultados

### DIFF
--- a/src/controllers/HorarioController.js
+++ b/src/controllers/HorarioController.js
@@ -1,7 +1,21 @@
-import loadHorarios from "../utils/data";
+import loadHorarios, { sortBy } from "../utils/data";
 
 let horarios;
 loadHorarios().then(response => (horarios = response));
+
+const supportedSortFilters = [
+  "professor",
+  "categoria",
+  "disciplina",
+  "sala",
+  "turma",
+  "periodo_ppc_antigo",
+  "periodo_ppc_novo"
+];
+
+function getOrderNum(orderParam) {
+  return orderParam === "asc" ? 1 : orderParam === "desc" ? -1 : 1;
+}
 
 function containsQuery(query) {
   return query !== undefined && query !== null;
@@ -49,6 +63,17 @@ function applyQueryFilters(queries) {
   if (containsQuery(queries.periodo_ppc_novo)) {
     horariosAndQueryFilters = horariosAndQueryFilters.filter(
       horario => horario.periodo_ppc_novo === queries.periodo_ppc_novo
+    );
+  }
+
+  if (
+    containsQuery(queries.sort_by) &&
+    supportedSortFilters.includes(queries.sort_by)
+  ) {
+    const orderNum = getOrderNum(queries.order); // by default is ascending -> 1
+
+    horariosAndQueryFilters = horariosAndQueryFilters.sort(
+      sortBy(queries.sort_by, orderNum)
     );
   }
 

--- a/src/utils/data.js
+++ b/src/utils/data.js
@@ -1,49 +1,60 @@
-import { readFile } from '.';
-const CSV_NAME = 'horario20191.csv';
+import { readFile } from ".";
+const CSV_NAME = "horario20191.csv";
 
-const sortByDisciplina = function(a, b) {
-    if (a.disciplina < b.disciplina) {
-        return -1;
+export function sortBy(criteria, order) {
+  return function(a, b) {
+    if (a[criteria] < b[criteria]) {
+      return -1 * order;
     }
-    if (a.disciplina > b.disciplina) {
-        return 1;
+    if (a[criteria] > b[criteria]) {
+      return 1 * order;
     }
     return 0;
-};
+  };
+}
+
+const sortByDisciplina = sortBy("disciplina", 1);
 
 const dias = {
-    s: 'segunda',
-    t: 'terca',
-    q: 'quarta',
-    i: 'quinta',
-    x: 'sexta'
+  s: "segunda",
+  t: "terca",
+  q: "quarta",
+  i: "quinta",
+  x: "sexta"
 };
 
 /**
  * Converte uma linha não formatada de um arquivo .csv em um objeto especifico (horario)
- * @param {string} line Uma linha de um arquivo csv 
+ * @param {string} line Uma linha de um arquivo csv
  */
-const convertToObject = (line) => {
-    var [ sala, disciplina_turma, professor, categoria, periodo_composto, horario ] = line.split(',');
-    var turma = disciplina_turma.split('-').pop();
-    var disciplina = disciplina_turma.slice(0, -3);
-    var [ periodo_ppc_antigo, periodo_ppc_novo ] = periodo_composto.split(';');
-    var dia = horario[0];
-    var hora = horario.substring(1);
-  
-    return {
-        sala,
-        disciplina,
-        turma,
-        professor,
-        categoria,
-        periodo_ppc_antigo,
-        periodo_ppc_novo,
-        horario: {
-            dia: dias[dia],
-            hora
-        }
-    };
+const convertToObject = line => {
+  var [
+    sala,
+    disciplina_turma,
+    professor,
+    categoria,
+    periodo_composto,
+    horario
+  ] = line.split(",");
+  var turma = disciplina_turma.split("-").pop();
+  var disciplina = disciplina_turma.slice(0, -3);
+  var [periodo_ppc_antigo, periodo_ppc_novo] = periodo_composto.split(";");
+  var dia = horario[0];
+  var hora = horario.substring(1);
+
+  return {
+    sala,
+    disciplina,
+    turma,
+    professor,
+    categoria,
+    periodo_ppc_antigo,
+    periodo_ppc_novo,
+    horario: {
+      dia: dias[dia],
+      hora
+    }
+  };
 };
 
 /**
@@ -51,13 +62,13 @@ const convertToObject = (line) => {
  * Retorna uma promise, contendo os horarios.
  */
 export default async function buildSchedule() {
-    var horarios;
+  var horarios;
 
-    await readFile(`src/csv/${CSV_NAME}`).then(content => {
-        var contentAsStringArray = content.split('\r\n');
-        contentAsStringArray.shift(); // Remove header (first element)
-        horarios = contentAsStringArray.map(convertToObject);
-    });
+  await readFile(`src/csv/${CSV_NAME}`).then(content => {
+    var contentAsStringArray = content.split("\r\n");
+    contentAsStringArray.shift(); // Remove header (first element)
+    horarios = contentAsStringArray.map(convertToObject);
+  });
 
-    return horarios.sort(sortByDisciplina);
+  return horarios.sort(sortByDisciplina);
 }


### PR DESCRIPTION
Implementado a ordenação por meio da query `sort_by` na qual os atributos suportados são os mesmos critérios de #27 

É possivel também definir a ordem em `asc` (ascendente) ou `desc` (descendente) por meio da query `order` que tem como valor padrão `asc` caso omitida.

Exemplo de request :
- `http://localhost:3000/horarios?professor=thiago&sort_by=disciplina`
- `http://localhost:3000/horarios?professor=thiago&sort_by=disciplina&order=desc`