### PR TITLE
Adiciona novas siglas e seus significados.

### DIFF
--- a/src/utils/data.js
+++ b/src/utils/data.js
@@ -76,6 +76,17 @@ const nomesDasDisciplinas = {
     "es": "Engenharia de Software",
     "linear": "Álgebra Linear",
     "irc/lirc": "Interconexão de Redes de Computadores/Laboratório de Interconexão de Redes de Computadores",
+    "adm-si": "Administração de Sistemas",
+    "estatistica-aplicada": "Estatística Aplicada",
+    "adsd": "Avaliação de Desempenho de Sistemas Discretos",
+    "msn": "Métodos e Softwares Númericos",
+    "rec-informacao": "Recuperação da Informação e Busca na Web",
+    "intro-prob": "Introdução à Probabilidade",
+    "empsoft": "Empreendedorismo em Software",
+    "atal": "Análise e Técnicas de Algoritmos",
+    "analise-sistemas": "Análise de Sistemas",
+    "logica": "Lógica para computação",
+    "v&v-testes": "Verificação e Validação de Software",
 };
 
 /**


### PR DESCRIPTION
#39 
Siglas adicionadas:
"adm-si": "Administração de Sistemas",
"estatistica-aplicada": "Estatística Aplicada",
"adsd": "Avaliação de Desempenho de Sistemas Discretos",
"msn": "Métodos e Softwares Númericos",
"rec-informacao": "Recuperação da Informação e Busca na Web",
"intro-prob": "Introdução à Probabilidade",
"empsoft": "Empreendedorismo em Software",
"atal": "Análise e Técnicas de Algoritmos",
"analise-sistemas": "Análise de Sistemas",
"logica": "Lógica para computação",
"v&v-testes": "Verificação e Validação de Software",