### PR TITLE
Update data.js

### DIFF
--- a/src/utils/data.js
+++ b/src/utils/data.js
@@ -76,6 +76,11 @@ const nomesDasDisciplinas = {
     "es": "Engenharia de Software",
     "linear": "Álgebra Linear",
     "irc/lirc": "Interconexão de Redes de Computadores/Laboratório de Interconexão de Redes de Computadores",
+    "intro-prob": "Introdução à Probabilidade",
+    "estatistica-aplicada": "Estatística Aplicada",
+    "prog-funcional": "Programação Funcional",
+    "analise-sistemas": "Análise de Sistemas",
+    "logica": "Lógica para Computação",
 };
 
 /**


### PR DESCRIPTION
#39 
- Adicionando mapeamento de siglas das disciplinas:

- [x] intro-prob: Introdução à Probabilidade
- [x] estatistica-aplicada: Estatística Aplicada
- [x] prog-funcional: Programação Funcional
- [x] analise-sistemas: Análise de Sistemas
- [x] logica: Lógica para Computação

**Percebi que a disciplina `atal` já esta adicionada, mas na issue ainda mostra como se não estivesse**